### PR TITLE
For soundwire 20190819

### DIFF
--- a/drivers/soundwire/algo_dynamic_allocation.c
+++ b/drivers/soundwire/algo_dynamic_allocation.c
@@ -53,7 +53,7 @@ static void sdw_compute_slave_ports(struct sdw_master_runtime *m_rt,
 			ch = sdw_ch_mask_to_ch(p_rt->ch_mask);
 
 			sdw_fill_xport_params(&p_rt->transport_params,
-					      p_rt->num, true,
+					      p_rt->num, false,
 					      SDW_BLK_GRP_CNT_1,
 					      sample_int, port_bo, port_bo >> 8,
 					      t_data->hstart,
@@ -96,7 +96,7 @@ static void sdw_compute_master_ports(struct sdw_master_runtime *m_rt,
 		no_ch = sdw_ch_mask_to_ch(p_rt->ch_mask);
 
 		sdw_fill_xport_params(&p_rt->transport_params, p_rt->num,
-				      true, SDW_BLK_GRP_CNT_1, sample_int,
+				      false, SDW_BLK_GRP_CNT_1, sample_int,
 				      port_bo, port_bo >> 8, hstart, hstop,
 				      (SDW_BLK_GRP_CNT_1 * no_ch), 0x0);
 

--- a/drivers/soundwire/cadence_master.h
+++ b/drivers/soundwire/cadence_master.h
@@ -24,6 +24,8 @@ struct sdw_cdns_pdi {
 	int l_ch_num;
 	int h_ch_num;
 	int ch_count;
+	int link_id;
+	int dai_id;
 	enum sdw_data_direction dir;
 	enum sdw_stream_type type;
 };
@@ -155,7 +157,7 @@ int sdw_cdns_get_stream(struct sdw_cdns *cdns,
 			u32 ch, u32 dir);
 struct sdw_cdns_pdi *sdw_cdns_alloc_pdi(struct sdw_cdns *cdns,
 					struct sdw_cdns_streams *stream,
-					u32 ch, u32 dir);
+					u32 ch, u32 dir, int dai_id);
 void sdw_cdns_config_stream(struct sdw_cdns *cdns,
 			    u32 ch, u32 dir, struct sdw_cdns_pdi *pdi);
 

--- a/drivers/soundwire/intel.c
+++ b/drivers/soundwire/intel.c
@@ -767,11 +767,10 @@ static int intel_hw_params(struct snd_pcm_substream *substream,
 	if (dma->stream_type == SDW_STREAM_PDM)
 		pcm = false;
 
-	/* FIXME: We would need to get PDI info from topology */
 	if (pcm)
-		pdi = sdw_cdns_alloc_pdi(cdns, &cdns->pcm, ch, dir);
+		pdi = sdw_cdns_alloc_pdi(cdns, &cdns->pcm, ch, dir, dai->id);
 	else
-		pdi = sdw_cdns_alloc_pdi(cdns, &cdns->pdm, ch, dir);
+		pdi = sdw_cdns_alloc_pdi(cdns, &cdns->pdm, ch, dir, dai->id);
 
 	if (!pdi) {
 		ret = -EINVAL;

--- a/sound/soc/intel/boards/cnl_rt700.c
+++ b/sound/soc/intel/boards/cnl_rt700.c
@@ -145,6 +145,8 @@ static int cnl_rt700_codec_fixup(struct snd_soc_pcm_runtime *rtd,
 
 SND_SOC_DAILINK_DEF(sdw0_pin2,
 	DAILINK_COMP_ARRAY(COMP_CPU("SDW0 Pin2")));
+SND_SOC_DAILINK_DEF(sdw0_pin3,
+	DAILINK_COMP_ARRAY(COMP_CPU("SDW0 Pin3")));
 SND_SOC_DAILINK_DEF(sdw0_codec,
 	DAILINK_COMP_ARRAY(COMP_CODEC("sdw:0:25d:700:0:0", "rt700-aif1")));
 
@@ -179,15 +181,24 @@ SND_SOC_DAILINK_DEF(platform,
 
 struct snd_soc_dai_link cnl_rt700_msic_dailink[] = {
 	{
-		.name = "SDW0-Codec",
+		.name = "SDW0-Playback",
 		.id = 0,
 		.be_hw_params_fixup = cnl_rt700_codec_fixup,
 		.ignore_suspend = 1,
 		.no_pcm = 1,
 		.dpcm_playback = 1,
-		.dpcm_capture = 1,
 		.nonatomic = true,
 		SND_SOC_DAILINK_REG(sdw0_pin2, sdw0_codec, platform),
+	},
+	{
+		.name = "SDW0-Capture",
+		.id = 1,
+		.be_hw_params_fixup = cnl_rt700_codec_fixup,
+		.ignore_suspend = 1,
+		.no_pcm = 1,
+		.dpcm_capture = 1,
+		.nonatomic = true,
+		SND_SOC_DAILINK_REG(sdw0_pin3, sdw0_codec, platform),
 	},
 	{
 		.name = "dmic01",


### PR DESCRIPTION
These commits are useful when I tested integration/soundwire-20190819 branch.
The first commit is for rt711 and rt1308 codecs, we can't play without it.
The second commit allow us to reuse the PDIs. It can solve run out of PDIs issue.
We can do playback/capture simultaneously with the third commit