### PR TITLE
Move regcache_mark_dirty to suspend and fix rt1308 kcontrol operation failed in suspend issue

### DIFF
--- a/sound/soc/codecs/rt1308-sdw.c
+++ b/sound/soc/codecs/rt1308-sdw.c
@@ -652,6 +652,7 @@ static int rt1308_dev_suspend(struct device *dev)
 		return 0;
 
 	regcache_cache_only(rt1308->regmap, true);
+	regcache_mark_dirty(rt1308->regmap);
 
 	return 0;
 }
@@ -675,7 +676,6 @@ static int rt1308_dev_resume(struct device *dev)
 	}
 
 	regcache_cache_only(rt1308->regmap, false);
-	regcache_mark_dirty(rt1308->regmap);
 	regcache_sync(rt1308->regmap);
 
 	return 0;

--- a/sound/soc/codecs/rt1308-sdw.c
+++ b/sound/soc/codecs/rt1308-sdw.c
@@ -52,7 +52,7 @@ static bool rt1308_volatile_register(struct device *dev, unsigned int reg)
 	case 0x3004 ... 0x3005:
 	case 0x3008:
 	case 0x300a:
-	case 0xc000 ... 0xcff3: /* Vendor-defined command */
+	case 0xc000:
 		return true;
 	default:
 		return false;

--- a/sound/soc/codecs/rt1308-sdw.h
+++ b/sound/soc/codecs/rt1308-sdw.h
@@ -139,6 +139,9 @@ static const struct reg_default rt1308_reg_defaults[] = {
 	{ 0x3005, 0x23 },
 	{ 0x3008, 0x02 },
 	{ 0x300a, 0x00 },
+	{ 0xc003 | (RT1308_DAC_SET << 4), 0x00 },
+	{ 0xc001 | (RT1308_POWER << 4), 0x00 },
+	{ 0xc002 | (RT1308_POWER << 4), 0x00 },
 };
 
 #define RT1308_SDW_OFFSET 0xc000

--- a/sound/soc/codecs/rt700-sdw.c
+++ b/sound/soc/codecs/rt700-sdw.c
@@ -253,6 +253,7 @@ static int rt700_dev_suspend(struct device *dev)
 		return 0;
 
 	regcache_cache_only(rt700->regmap, true);
+	regcache_mark_dirty(rt700->regmap);
 
 	return 0;
 }
@@ -276,7 +277,6 @@ static int rt700_dev_resume(struct device *dev)
 	}
 
 	regcache_cache_only(rt700->regmap, false);
-	regcache_mark_dirty(rt700->regmap);
 	regcache_sync(rt700->regmap);
 
 	return 0;

--- a/sound/soc/codecs/rt711-sdw.c
+++ b/sound/soc/codecs/rt711-sdw.c
@@ -476,6 +476,7 @@ static int rt711_dev_suspend(struct device *dev)
 		return 0;
 
 	regcache_cache_only(rt711->regmap, true);
+	regcache_mark_dirty(rt711->regmap);
 
 	return 0;
 }
@@ -499,7 +500,6 @@ static int rt711_dev_resume(struct device *dev)
 	}
 
 	regcache_cache_only(rt711->regmap, false);
-	regcache_mark_dirty(rt711->regmap);
 	regcache_sync(rt711->regmap);
 
 	return 0;

--- a/sound/soc/codecs/rt715-sdw.c
+++ b/sound/soc/codecs/rt715-sdw.c
@@ -265,6 +265,7 @@ static int rt715_dev_suspend(struct device *dev)
 		return 0;
 
 	regcache_cache_only(rt715->regmap, true);
+	regcache_mark_dirty(rt715->regmap);
 
 	return 0;
 }
@@ -288,7 +289,6 @@ static int rt715_dev_resume(struct device *dev)
 	}
 
 	regcache_cache_only(rt715->regmap, false);
-	regcache_mark_dirty(rt715->regmap);
 	regcache_sync(rt715->regmap);
 
 	return 0;


### PR DESCRIPTION
Reg cache is not aligned in suspended. So mark it dirty in suspend. 
The rt3108 related patches are checked by @shumingfan and tested on my side 