### PR TITLE
soundwire: intel: refine function for wakeen event processing

### DIFF
--- a/drivers/soundwire/intel.c
+++ b/drivers/soundwire/intel.c
@@ -473,13 +473,13 @@ void sdw_intel_process_wakeen_event(struct sdw_intel_ctx *ctx)
 		 * the wakeen event and let codec driver check codec status
 		 */
 		list_for_each_entry(slave, &bus->slaves, node) {
-			if (slave->prop.wake_capable) {
-				if (slave->status != SDW_SLAVE_ATTACHED &&
-				    slave->status != SDW_SLAVE_ALERT)
-					continue;
-
+			/*
+			 * discard devices that are defined in ACPI tables but
+			 * not physically present and devices that cannot
+			 * generate wakes
+			 */
+			if (slave->dev_num_sticky && slave->prop.wake_capable)
 				pm_request_resume(&slave->dev);
-			}
 		}
 	}
 }


### PR DESCRIPTION
when processing wakeen event, we need to wake up the slaves may generate this event.
This PR refines the processing function to discard the devices that are defined in ACPI tables but not physically present and devices that cannot generate wakes

if a slave has been attached to a bus, the slave->dev_num_sticky should be non-zero, so we can check this value to skip the ghost devices defined in ACPI table.

Signed-off-by: Rander Wang <rander.wang@intel.com>