### PR TITLE
soundwire: intel: refine runtime pm for SDW_INTEL_CLK_STOP_BUS_RESET

### DIFF
--- a/drivers/soundwire/intel.c
+++ b/drivers/soundwire/intel.c
@@ -1696,6 +1696,8 @@ static int intel_resume_runtime(struct device *dev)
 	struct sdw_cdns *cdns = dev_get_drvdata(dev);
 	struct sdw_intel *sdw = cdns_to_intel(cdns);
 	u32 clock_stop_quirks;
+	bool clock_stop0;
+	int status;
 	int ret;
 
 	if (cdns->bus.prop.hw_disabled) {
@@ -1741,11 +1743,22 @@ static int intel_resume_runtime(struct device *dev)
 		}
 
 		/*
+		 * An exception condition occurs for the CLK_STOP_BUS_RESET
+		 * case if one or more masters remain active. In this condition,
+		 * all the masters are powered on for they are in the same power
+		 * domain. Master can preserve its context for clock stop0, so
+		 * there is no need to clear slave status and reset bus.
+		 */
+		clock_stop0 = sdw_cdns_is_clock_stop(&sdw->cdns);
+
+		/*
 		 * make sure all Slaves are tagged as UNATTACHED and
 		 * provide reason for reinitialization
 		 */
-		sdw_clear_slave_status(&sdw->cdns.bus,
-				       SDW_UNATTACH_REQUEST_MASTER_RESET);
+		if (!clock_stop0) {
+			status = SDW_UNATTACH_REQUEST_MASTER_RESET;
+			sdw_clear_slave_status(&sdw->cdns.bus, status);
+		}
 
 		ret = sdw_cdns_enable_interrupt(cdns, true);
 		if (ret < 0) {
@@ -1753,7 +1766,7 @@ static int intel_resume_runtime(struct device *dev)
 			return ret;
 		}
 
-		ret = sdw_cdns_clock_restart(cdns, true);
+		ret = sdw_cdns_clock_restart(cdns, !clock_stop0);
 		if (ret < 0) {
 			dev_err(dev, "unable to restart clock during resume\n");
 			return ret;


### PR DESCRIPTION
There is a exception condition for CLK_STOP_BUS_RESET
case if there is another master is working. In this case,
all the masters are powered on for they are in the same
power domain. And master can preserve its context for
clock stop0, so there is no need to clear slave status and
reset bus.

Signed-off-by: Rander Wang <rander.wang@intel.com>